### PR TITLE
ci: reclaim runner disk before builds (fix "No space left on device")

### DIFF
--- a/.github/workflows/reusable-service-build.yml
+++ b/.github/workflows/reusable-service-build.yml
@@ -48,6 +48,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free up runner disk space
+        run: |
+          echo "Disk before cleanup:"; df -h /
+          # Reclaim ~25 GB of preinstalled SDKs we don't use, so testcontainers
+          # images, Gradle caches, and Docker layers fit on the ubuntu-latest
+          # runner (the Gradle cache-save post-step was hitting "No space left").
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /usr/local/share/boost /opt/hostedtoolcache/CodeQL \
+                      /usr/share/swift /usr/local/.ghcup || true
+          sudo docker image prune -af || true
+          echo "Disk after cleanup:"; df -h /
+
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@v5
         with:
@@ -99,6 +111,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free up runner disk space
+        run: |
+          echo "Disk before cleanup:"; df -h /
+          # Reclaim ~25 GB of preinstalled SDKs we don't use, so testcontainers
+          # images, Gradle caches, and Docker layers fit on the ubuntu-latest
+          # runner (the Gradle cache-save post-step was hitting "No space left").
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /usr/local/share/boost /opt/hostedtoolcache/CodeQL \
+                      /usr/share/swift /usr/local/.ghcup || true
+          sudo docker image prune -af || true
+          echo "Disk after cleanup:"; df -h /
+
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@v5
         with:
@@ -149,6 +173,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Free up runner disk space
+        run: |
+          echo "Disk before cleanup:"; df -h /
+          # Multi-arch Docker buildx is disk-heavy; reclaim unused SDKs first.
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /usr/local/share/boost /opt/hostedtoolcache/CodeQL \
+                      /usr/share/swift /usr/local/.ghcup || true
+          sudo docker image prune -af || true
+          echo "Disk after cleanup:"; df -h /
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@v5


### PR DESCRIPTION
## Why

The shared `reusable-service-build.yml` runs on `ubuntu-latest` (~14 GB free on `/`). Container-heavy builds exhaust it:
- the **test job** spins up testcontainers (Quarkus devservices, docling, wiremock engine, …),
- the **docker job** runs multi-arch `buildx`.

When the disk fills, `gradle/actions/setup-gradle`'s **post-job cache-save** dies with `No space left on device`. Observed on `module-testing-sidecar` `main` ([run 27978834324](https://github.com/ai-pipestream/module-testing-sidecar/actions/runs/27978834324)) — the build *and tests passed*; only the post-step cleanup failed, so the run was red for a non-code reason.

## What

Add a small, **dependency-free** reclaim step right after `Checkout code` in all three jobs (`build`, `publish-snapshots`, `docker-snapshot`):

- `rm -rf` preinstalled SDKs we never use — dotnet, ghc/ghcup, android, boost, CodeQL, swift (~25 GB),
- `docker image prune -af` for dangling layers.

Guards:
- Runs **before** the JDK/Gradle toolchains install, so it never touches the Java tool cache.
- Every command is `|| true`, so the step can never fail a job.
- No third-party action — just `rm`/`df`/`docker`, fully auditable.

## Effect

Frees ~25 GB per build, clearing the cache-save failure and giving testcontainers + buildx room. Fixes `module-testing-sidecar` and the same latent risk in every consumer (parser, semantic-graph, quality, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)