### PR TITLE
ci: run service builds on the self-hosted runner

### DIFF
--- a/.github/workflows/reusable-service-build.yml
+++ b/.github/workflows/reusable-service-build.yml
@@ -40,7 +40,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 45
     env:
       # Surfaced as job-level env so the Setup Buf step's `if` can gate on it.
       BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
@@ -55,6 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Free up runner disk space
+        if: runner.environment == 'github-hosted'
         run: |
           echo "Disk before cleanup:"; df -h /
           # Reclaim ~25 GB of preinstalled SDKs we don't use, so testcontainers
@@ -106,7 +108,8 @@ jobs:
           path: build/test-results/
 
   publish-snapshots:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 45
     needs: build
     if: github.ref == 'refs/heads/main'
     env:
@@ -121,6 +124,7 @@ jobs:
           fetch-depth: 0
 
       - name: Free up runner disk space
+        if: runner.environment == 'github-hosted'
         run: |
           echo "Disk before cleanup:"; df -h /
           # Reclaim ~25 GB of preinstalled SDKs we don't use, so testcontainers
@@ -172,7 +176,8 @@ jobs:
         run: ./gradlew publish -PskipCentral=true --no-daemon --stacktrace
 
   docker-snapshot:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 45
     needs:
       - build
       - publish-snapshots
@@ -187,6 +192,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Free up runner disk space
+        if: runner.environment == 'github-hosted'
         run: |
           echo "Disk before cleanup:"; df -h /
           # Multi-arch Docker buildx is disk-heavy; reclaim unused SDKs first.


### PR DESCRIPTION
## What

Flips the org **reusable service build** (`reusable-service-build.yml`) — which every service repo (module-chunker, embedder, …) calls — onto the **self-hosted runner**, so CI stops consuming metered GitHub-hosted minutes (all repos are private now).

- `runs-on: ubuntu-latest` → `runs-on: self-hosted` on all three jobs (build, publish-snapshots, docker-snapshot)
- `timeout-minutes: 45` on each — a hang can't pin the runner for hours
- the **"Free up runner disk space"** step is gated to `runner.environment == 'github-hosted'` — on a self-hosted box it's pointless (2.7 TB free) and its `docker image prune -af` could nuke images the host still needs

## Effect
Because consumers reference this workflow `@main`, it takes effect the moment this merges. The next service-repo build runs on the `krick` runner (Docker 29.6.1, JDK 25, 2.7 TB) at **\$0 / unmetered**.

## Rollout
Start here (covers all Java service repos). The **frontend**, **pipestream-protos**, and **pipestream-platform** workflows have their own `runs-on` and aren't covered by this file — I'll flip those next once we confirm a real service build runs green on krick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)